### PR TITLE
pull changes from bullsfirst

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -18,7 +18,7 @@ var require = {
         // Backbone
         backbone:       'vendor/backbone.min',
 
-        // Framework
+        // Keel
         BaseView:       'keel/BaseView',
         ExceptionUtil:  'keel/ExceptionUtil',
         Message:        'keel/Message',

--- a/src/keel/BaseView.js
+++ b/src/keel/BaseView.js
@@ -19,7 +19,7 @@
 
 
 /**
-* framework/BaseView
+* keel/BaseView
 *
 * This is a view base class built on top of the default Backbone.View; it
 * provides a set of rendering, binding, and lifecycle methods that tend to
@@ -377,7 +377,11 @@ function( ExceptionUtil, Backbone, _, $ ) {
 
             var template = this.getTemplate();
             var model = this.model || {};
-            var context = model.toJSON ? model.toJSON() : {};
+
+            // If the model contains a toJSON method, call it to create the context.
+            // Otherwise assume that the model contains properties that will be
+            // displayed as is.
+            var context = model.toJSON ? model.toJSON() : model;
 
             // Remove existing children
             this.destroyChildren();

--- a/src/keel/ExceptionUtil.js
+++ b/src/keel/ExceptionUtil.js
@@ -15,10 +15,10 @@
 */
 
 /**
-* framework/ExceptionUtil
-* This is an Exception Utility intended to be used within the framework
+* keel/ExceptionUtil
+* This is an Exception Utility intended to be used within Keel
 * for alerting implementors about errors such as bad arguments passed to
-* framework methods.
+* Keel methods.
 *
 * It includes a general FrameworkException constructor. This could be extended
 * if necessary to present more specific exceptions if necessary.

--- a/src/keel/Message.js
+++ b/src/keel/Message.js
@@ -15,7 +15,7 @@
  */
 
 /**
- * framework/Message
+ * keel/Message
  *
  * Enumeration of messages
  *
@@ -29,7 +29,7 @@ define(function() {
     /**
     * The Message enumerator
     * Defines string message names for the MessageBus for easier maintenance.
-    * framework/Message be extended within the app.
+    * keel/Message be extended within the app.
     *
     * @class Message
     * @static

--- a/src/keel/MessageBus.js
+++ b/src/keel/MessageBus.js
@@ -15,7 +15,7 @@
 */
 
 /**
-* framework/MessageBus
+* keel/MessageBus
 *
 * Provides the ability to publish and subscribe to messages.
 *

--- a/src/keel/Router.js
+++ b/src/keel/Router.js
@@ -15,7 +15,7 @@
 */
 
 /**
-* framework/Router
+* keel/Router
 *
 * Extends Backbone.Router to route to different pages in the application.
 *


### PR DESCRIPTION
change from bullsfirst to use the model instead of an empty object if toJSON is not available

updated documentation references from framework/<whatever> to keel/<whatever>
