### PR TITLE
allow null templates. fixes #30

### DIFF
--- a/src/keel/BaseView.js
+++ b/src/keel/BaseView.js
@@ -284,6 +284,13 @@ function( ExceptionUtil, Backbone, _, $ ) {
         **/
         getTemplate: function() {
 
+            if (!this.template) {
+                
+                // When applied, this function will return undefined
+                // jQuery.html() shortcuts if the argument is undefined as opposed to null or the empty string
+                return function(){};
+            }
+
             if ( !_templates[this.template.name] ) {
                 _templates[ this.template.name ] = _.template( this.template.source );
             }

--- a/tests/specs/framework/BaseView.js
+++ b/tests/specs/framework/BaseView.js
@@ -10,21 +10,36 @@ define([
 ], function(Backbone, BaseView, $) {
     'use strict';
 
+    var Construct = null;
+    var Construct2 = null;
     var BV = null;
+    var BV2 = null;
 
     describe('BaseView', function() {
 
         beforeEach(function() {
             $('#test').empty();
-            BV = new BaseView({
+            Construct = BaseView.extend({
                 tagName: 'section',
                 className: 'test-base-view'
             });
+
+            Construct2 = BaseView.extend({
+                tagName: 'section',
+                className: 'test-base-view-2',
+                template: null
+            });
+
+            BV = new Construct();
+            BV2 = new Construct2();
         });
 
         afterEach(function() {
             $('#test').empty();
+            Construct = null;
+            Construct2 = null;
             BV = null;
+            BV2 = null;
         });
 
         describe('#addChild()', function() {
@@ -317,6 +332,16 @@ define([
                 // invoke again to get template string
                 // Since the default template has no variables, it should match the template source
                 expect(BV.getTemplate()()).to.equal(BV.template.source);
+
+            });
+
+            it('should handle a null template', function() {
+
+                console.log(BV2.getTemplate()());
+
+                // invoke getTemplate() to get the function that returns the template
+                // invoke again to get template string, which should be empty
+                expect(BV2.getTemplate()()).to.be.undefined;
 
             });
 


### PR DESCRIPTION
the value for template can now be set to null. This removes the need for empty template files or setting template.source to an empty string

updated tests to verify this works in the future
